### PR TITLE
add OIDC code

### DIFF
--- a/identity-team-account/main.tf
+++ b/identity-team-account/main.tf
@@ -1,0 +1,73 @@
+# identity-team-account의 main.tf
+# modules/github_oidc를 불러와 해당account별 OIDC역할을 자동으로 생성하는 구조
+
+module "github_oidc" {
+  source = "../modules/github_oidc"
+
+  role_name = "identity-role"  
+
+  # GitHub Actions에서 이 role을 사용할 수 있도록 허용하는 sub조건
+  sub_condition = "repo:repo:WHS-DevSecOps-infra/Organization:*" 
+
+  # 이 role에 연결할 정책들(IAM 정책 ARN)
+  policy_arns = [
+    "arn:aws:iam::aws:policy/AdministratorAccess",
+    ""   
+  ]
+}
+
+resource "aws_iam_role_policy" "custom_inline_policy" {
+  name = "CustomOIDCPolicy"
+  role = module.github_oidc.oidc_role_name  # 모듈에서 출력된 role이름 참조
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+            "sso:CreatePermissionSet",
+			"sso:DescribePermissionSet",
+			"sso:UpdatePermissionSet",
+			"sso:DeletePermissionSet",
+			"sso:AttachManagedPolicyToPermissionSet",
+			"sso:ListPermissionSets",
+			"sso:ListInstances",
+			"sso:ProvisionPermissionSet",
+			"sso:PutInlinePolicyToPermissionSet",
+			"sso:DeleteInlinePolicyFromPermissionSet",
+			"sso:ListPermissionSetProvisioningStatus",
+			"organizations:*",
+			"identitystore:*"
+        ],
+        Resource = "*"
+      },
+      {
+			"Sid": "S3Access",
+			"Effect": "Allow",
+			"Action": [
+				"s3:*"
+			],
+			"Resource": [
+				"*"
+			]
+		},
+		{
+			"Sid": "KMSAccess",
+			"Effect": "Allow",
+			"Action": [
+				"kms:*"
+			],
+			"Resource": "*"
+		},
+		{
+			"Sid": "DynamoDBAccess",
+			"Effect": "Allow",
+			"Action": [
+				"dynamodb:*"
+			],
+			"Resource": "*"
+		}
+    ]
+  })
+}

--- a/modules/github_oidc/main.tf
+++ b/modules/github_oidc/main.tf
@@ -1,0 +1,40 @@
+#현재 계정정보를 가져옴
+data "aws_caller_identity" "current" {}
+
+# GitHub Actions용 OIDC provider 설정
+resource "aws_iam_openid_connect_provider" "github" {
+  url = "https://token.actions.githubusercontent.com"
+
+  client_id_list = [
+    "sts.amazonaws.com"  # OIDC에서 사용할 클라이언트 ID
+  ]
+
+  thumbprint_list = [
+    "6938fd4d98bab03faadb97b34396831e3780aea1" # GitHub 공식 인증서 지문 thumbprint(공식값)
+  ]
+}
+
+# oidc_role 이라는 이름의 IAM Role
+resource "aws_iam_role" "oidc_role" {
+  name = var.role_name  # 생성할 Role 이름
+
+# GitHub에서 이 역할을 assume할 수 있게 설정
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github.arn # 위에서 만든 OIDC Provider의 ARN
+        },
+        Action = "sts:AssumeRoleWithWebIdentity",
+        Condition = {
+          StringLike = {
+            # 어떤 GitHub repo에서만 이 Role을 사용할 수 있는지 제어
+            "token.actions.githubusercontent.com:sub": var.sub_condition
+          }
+        }
+      }
+    ]
+  })
+}

--- a/modules/github_oidc/variables.tf
+++ b/modules/github_oidc/variables.tf
@@ -1,0 +1,21 @@
+variable "role_name" {
+  type        = string
+  description = "OIDC 역할 이름"
+}
+
+variable "sub_condition" {
+  type        = string
+  description = "OIDC Subject (sub) 조건"
+}
+
+variable "policy_arns" {
+  type        = list(string)
+  description = "Attach할 IAM 정책 목록"
+}
+
+resource "aws_iam_role_policy_attachment" "attach_policy" {
+  for_each   = toset(var.policy_arns)
+  role       = aws_iam_role.oidc_role.name
+  policy_arn = each.value
+}
+

--- a/modules/outputs.tf
+++ b/modules/outputs.tf
@@ -1,0 +1,4 @@
+output "oidc_role_name" {
+  description = "OIDC로 생성된 IAM Role 이름"
+  value       = aws_iam_role.oidc_role.name
+}


### PR DESCRIPTION
## #️⃣ Related Issues

> e.g. #65 

## 📝 Work Summary

> GitHub Actions OIDC 설정 코드화

**GitHub Actions와 AWS OIDC 연동을 코드로 자동화하기 위한 `modules/github_oidc` 모듈을 생성하고, 이를 identity-team-account에 적용**

- `modules/github_oidc/` 디렉토리 생성
  - `main.tf`: OIDC Provider 및 IAM Role/Policy 구성
  - `variables.tf`: account마다 다른 role 이름, sub 조건, 정책을 주입 가능하도록 변수화
  - `outputs.tf`: 외부에서 IAM Role 이름 참조 가능하도록 출력값 정의

- `identity-team-account/main.tf`에 OIDC 모듈 적용
  - `module "github_oidc"` 블록을 통해 역할 생성
  - `module.github_oidc.oidc_role_name`을 참조하여 인라인 정책 부여
  - 관리 정책(`AdministratorAccess` 등)과 커스텀 인라인 정책 병행 사용

> github actions와 AWS OIDC 연동 흐름

1. github actions는 worflow 실행 시, OIDC 토큰을 자동으로 발급함
2. modules/github_oidc/main.tf의 github OIDC provider 설정을 통해 AWS가 github의 OIDC 토큰을 신뢰하게 됨
3. assume_role_policy를 통해 IAM Role 생성 및 연결하게 되면, 워크플로우에서 Assume Role 실행

## 💬 Review Notes 

> 혹시 정책이 부족하게 들어가 있는지 확인부탁드립니다.