### PR TITLE
fix:78: remove application team's management account permssion

### DIFF
--- a/identity-team-account/organization/ssoadmin/main.tf
+++ b/identity-team-account/organization/ssoadmin/main.tf
@@ -200,7 +200,6 @@ locals {
   application_team_admin_accounts = {}
   application_team_readonly_accounts = {
     identity_account   = data.terraform_remote_state.organization.outputs.identity_account_id,
-    management_account = data.terraform_remote_state.organization.outputs.management_account_id,
     prod_account       = data.terraform_remote_state.organization.outputs.prod_account_id,
     operation_account  = data.terraform_remote_state.organization.outputs.operation_account_id,
     security_account   = data.terraform_remote_state.organization.outputs.security_account_id,

--- a/identity-team-account/organization/ssoadmin/main.tf
+++ b/identity-team-account/organization/ssoadmin/main.tf
@@ -199,12 +199,12 @@ locals {
 
   application_team_admin_accounts = {}
   application_team_readonly_accounts = {
-    identity_account   = data.terraform_remote_state.organization.outputs.identity_account_id,
-    prod_account       = data.terraform_remote_state.organization.outputs.prod_account_id,
-    operation_account  = data.terraform_remote_state.organization.outputs.operation_account_id,
-    security_account   = data.terraform_remote_state.organization.outputs.security_account_id,
-    dev_account        = data.terraform_remote_state.organization.outputs.dev_account_id,
-    stage_account      = data.terraform_remote_state.organization.outputs.stage_account_id
+    identity_account  = data.terraform_remote_state.organization.outputs.identity_account_id,
+    prod_account      = data.terraform_remote_state.organization.outputs.prod_account_id,
+    operation_account = data.terraform_remote_state.organization.outputs.operation_account_id,
+    security_account  = data.terraform_remote_state.organization.outputs.security_account_id,
+    dev_account       = data.terraform_remote_state.organization.outputs.dev_account_id,
+    stage_account     = data.terraform_remote_state.organization.outputs.stage_account_id
   }
 }
 


### PR DESCRIPTION
## #️⃣ Related Issues

#78 

## 📝 Work Summary
- application 팀의 management account에 대한 read_only 권한 제거

### Screenshot (Optional)

## 💬 Review Notes (Optional)

> Add any specific points you would like the reviewers to focus on.