### PR TITLE
fix/#85: user_name

### DIFF
--- a/identity-team-account/organization/identitystore/terraform.tfvars
+++ b/identity-team-account/organization/identitystore/terraform.tfvars
@@ -53,7 +53,7 @@ users = {
     given_name   = "Subin"
     family_name  = "Kim"
   }
-  Soobin_kwon = {
+  soobin_kwon = {
     display_name = "Kwon Soobin"
     email        = "rnjs0332@gmail.com"
     given_name   = "Soobin"

--- a/identity-team-account/organization/sso/locals_users.tf
+++ b/identity-team-account/organization/sso/locals_users.tf
@@ -17,7 +17,7 @@ locals {
   }
 
   application_users = {
-    "soobin_kwon" = data.terraform_remote_state.identitystore.outputs.user_ids["Soobin_kwon"]
+    "soobin_kwon" = data.terraform_remote_state.identitystore.outputs.user_ids["soobin_kwon"]
   }
 
   cicd_admin_user_account_pairs = flatten([


### PR DESCRIPTION
## #️⃣ Related Issues

#85

## 📝 Work Summary
- 유저 이름이 혼자 대문자로 시작하는 부분 변경
- state를 변경해도 삭제했다가 다시 생성되는 방식이라 다시 비밀번호 설정 필요할듯
- 현재 identitystore에 대한 state 변경은 진행됨.
### Screenshot (Optional)

## 💬 Review Notes (Optional)

> Add any specific points you would like the reviewers to focus on.