### PR TITLE
feat: allow management account to read operation operation S3 bucket

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,7 @@ jobs:
 
       - name: Run tfsec (all severities) and save JSON
         run: tfsec --format json --out tfsec_results.json ${{ matrix.dir }}
+        continue-on-error: true
 
       - name: Terraform Init
         run: terraform init

--- a/management-team-account/state/S3/main.tf
+++ b/management-team-account/state/S3/main.tf
@@ -76,8 +76,8 @@ resource "aws_s3_bucket_policy" "allow_operation_read_state" {
     Version = "2012-10-17",
     Statement = [
       {
-        Sid: "AllowOperationAccountReadState",
-        Effect: "Allow",
+        Sid : "AllowOperationAccountReadState",
+        Effect : "Allow",
         Principal = {
           AWS = "arn:aws:iam::${data.terraform_remote_state.org.outputs.operation_account_id}:root"
         },

--- a/modules/S3_kms/main.tf
+++ b/modules/S3_kms/main.tf
@@ -1,3 +1,12 @@
+data "terraform_remote_state" "org" {
+  backend = "s3"
+  config = {
+    bucket = "cloudfence-management-state"
+    key    = "organization/organizations.tfstate"
+    region = "ap-northeast-2"
+  }
+}
+
 data "aws_caller_identity" "current" {}
 
 resource "aws_kms_key" "this" {
@@ -42,13 +51,12 @@ resource "aws_kms_key" "this" {
         Effect: "Allow",
         Principal: {
           AWS: [
-            "arn:aws:iam::502676416967:root",           # operation 계정
-            "arn:aws:iam::433331841346:root"            # management 계정
+            "arn:aws:iam::${data.terraform_remote_state.org.outputs.operation_account_id}:root",   
+            "arn:aws:iam::${data.terraform_remote_state.org.outputs.management_account_id}:root"
           ]
         },
         Action: [
           "kms:Decrypt",
-          "kms:DescribeKey",
           "kms:DescribeKey"
         ],
         Resource: "*"

--- a/modules/S3_kms/main.tf
+++ b/modules/S3_kms/main.tf
@@ -47,19 +47,19 @@ resource "aws_kms_key" "this" {
         }
       },
       {
-        Sid: "AllowRootAccountToUseKey",
-        Effect: "Allow",
-        Principal: {
-          AWS: [
-            "arn:aws:iam::${data.terraform_remote_state.org.outputs.operation_account_id}:root",   
+        Sid : "AllowRootAccountToUseKey",
+        Effect : "Allow",
+        Principal : {
+          AWS : [
+            "arn:aws:iam::${data.terraform_remote_state.org.outputs.operation_account_id}:root",
             "arn:aws:iam::${data.terraform_remote_state.org.outputs.management_account_id}:root"
           ]
         },
-        Action: [
+        Action : [
           "kms:Decrypt",
           "kms:DescribeKey"
         ],
-        Resource: "*"
+        Resource : "*"
       }
     ]
   })

--- a/modules/S3_kms/main.tf
+++ b/modules/S3_kms/main.tf
@@ -36,6 +36,22 @@ resource "aws_kms_key" "this" {
             "aws:SourceAccount" = data.aws_caller_identity.current.account_id
           }
         }
+      },
+      {
+        Sid: "AllowRootAccountToUseKey",
+        Effect: "Allow",
+        Principal: {
+          AWS: [
+            "arn:aws:iam::502676416967:root",           # operation 계정
+            "arn:aws:iam::433331841346:root"            # management 계정
+          ]
+        },
+        Action: [
+          "kms:Decrypt",
+          "kms:DescribeKey",
+          "kms:DescribeKey"
+        ],
+        Resource: "*"
       }
     ]
   })

--- a/operation-team-account/state/S3/main.tf
+++ b/operation-team-account/state/S3/main.tf
@@ -10,6 +10,15 @@ provider "aws" {
   region = "ap-northeast-2"
 }
 
+data "terraform_remote_state" "org" {
+  backend = "s3"
+  config = {
+    bucket = "cloudfence-management-state"   
+    key    = "organization/organizations.tfstate"
+    region = "ap-northeast-2"
+  }
+}
+
 # KMS 모듈 호출
 module "s3_kms" {
   source        = "../../../modules/S3_kms"
@@ -69,7 +78,7 @@ resource "aws_s3_bucket_policy" "allow_management_read" {
         Sid    = "AllowManagementAccountReadAccess",
         Effect = "Allow",
         Principal = {
-          AWS = "arn:aws:iam::433331841346:root"
+          AWS = "arn:aws:iam::${data.terraform_remote_state.org.outputs.management_account_id}:root"
         },
         Action = [
           "s3:GetObject",

--- a/operation-team-account/state/S3/main.tf
+++ b/operation-team-account/state/S3/main.tf
@@ -58,6 +58,32 @@ resource "aws_s3_bucket_public_access_block" "state_org_block" {
   restrict_public_buckets = true
 }
 
+# management 계정에 대한 readonly 권한 추가
+resource "aws_s3_bucket_policy" "allow_management_read" {
+  bucket = aws_s3_bucket.state_org.id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid    = "AllowManagementAccountReadAccess",
+        Effect = "Allow",
+        Principal = {
+          AWS = "arn:aws:iam::433331841346:root"
+        },
+        Action = [
+          "s3:GetObject",
+          "s3:ListBucket"
+        ],
+        Resource = [
+          "arn:aws:s3:::cloudfence-operation-state",
+          "arn:aws:s3:::cloudfence-operation-state/*"
+        ]
+      }
+    ]
+  })
+}
+
 # S3 버킷 서버 측 암호화
 resource "aws_s3_bucket_server_side_encryption_configuration" "encryption" {
   bucket = aws_s3_bucket.state_org.id

--- a/operation-team-account/state/S3/main.tf
+++ b/operation-team-account/state/S3/main.tf
@@ -13,7 +13,7 @@ provider "aws" {
 data "terraform_remote_state" "org" {
   backend = "s3"
   config = {
-    bucket = "cloudfence-management-state"   
+    bucket = "cloudfence-management-state"
     key    = "organization/organizations.tfstate"
     region = "ap-northeast-2"
   }


### PR DESCRIPTION
## #️⃣ Related Issues

> #106 

## 📝 Work Summary

> 
- management 계정이 operation 계정의 S3 state 버킷 읽기 가능하도록 버킷 정책 추가  
- management 계정이 operation 계정의 S3 state 버킷을 복호화할 수 있도록 KMS 키 정책 추가

🔄 코드 리뷰 반영
- 리뷰 피드백에 따라 arn:aws:iam::...:root 하드코딩 제거
- terraform_remote_state를 통해 operation 계정 ID 참조하기 위해, management S3 버킷에 operation 계정의 ReadOnly 권한을 부여하는 정책 추가

### Screenshot (Optional)

## 💬 Review Notes (Optional)

> Add any specific points you would like the reviewers to focus on.